### PR TITLE
Startup and liveness checks for nodes

### DIFF
--- a/bases/node/node.yaml
+++ b/bases/node/node.yaml
@@ -292,6 +292,18 @@ spec:
               name: prom
             - containerPort: 1317
               name: api
+          startupProbe:
+            httpGet:
+              path: /health
+              port: rpc
+            failureThreshold: 100
+            periodSeconds: 6
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: rpc
+            failureThreshold: 15
+            periodSeconds: 6
           volumeMounts:
             - name: state
               mountPath: /state

--- a/bases/node/node.yaml
+++ b/bases/node/node.yaml
@@ -296,14 +296,22 @@ spec:
             httpGet:
               path: /health
               port: rpc
-            failureThreshold: 100
-            periodSeconds: 6
+            failureThreshold: 120
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command:
+                - bash
+                - -c
+                - agd status | jq '.SyncInfo.catching_up' | grep false
+            initialDelaySeconds: 10
+            periodSeconds: 10
           livenessProbe:
             httpGet:
               path: /health
               port: rpc
-            failureThreshold: 15
-            periodSeconds: 6
+            failureThreshold: 3
+            periodSeconds: 10
           volumeMounts:
             - name: state
               mountPath: /state


### PR DESCRIPTION
refs: https://github.com/Agoric/instagoric-private/issues/2

This PR modifies the spec for nodes, the base from which validators and seed inherit. 

The startup probe checks that RPC has come up during (re)deployment. It lets K8s know whether the service is actually functional beyond the container starting. If no probes are successful (for 6 * 100 seconds), the pod is restarted.

After a single successful startup probe, the liveness probe should take over. If RPC endpoint is inaccessible for 90 (6 * 15) seconds, the pod is killed and restarted.

### Test Plan

I applied these changes to loadtest via `init.sh loadtest`.

`validator-0` goes down: `kubectl exec -n instagoric -- pkill -9 node`

Verify by checking agd, which hits the RPC endpoint locally: 

`kubectl exec -ti -n instagoric validator-0 -- agd status`
`Error: post failed: Post "http://localhost:26657": dial tcp 127.0.0.1:26657: connect: connection refused`

Watch k8s detect the failure and bring it back:

`kubectl get pods -n instagoric -w`

After threshold we should see new output for bringing container back up. Note restarts count increases.

```
NAME                        READY   STATUS    RESTARTS   AGE
validator-0                 4/5     Running   1 (1s ago)   4m38s
validator-0                 4/5     Running   1 (8s ago)   4m45s
validator-0                 5/5     Running   1 (8s ago)   4m45s
```

agd also works again:

`kubectl exec -ti -n instagoric validator-0 -- agd status`
```
{"NodeInfo":{"protocol_version":{"p2p":"8","block":"11","app":"0"},"id":"fd414a649f618e1fe66108b9c45cfcfc54835124","listen_addr":"tcp://0.0.0.0:26656","network":"agoricloadtest-42","version":"0.34.23","channels":"40202122233038606100","moniker":"validator-0","other":{"tx_index":"on","rpc_address":"tcp://0.0.0.0:26657"}},"SyncInfo":{"latest_block_hash":"D7132E5626CFF72EF55E201CF0FE6C296F67AA92FD6A9548399D66E9D7CF9522","latest_app_hash":"64E00D23A05ADF1CEE3393C60D25E8716F135B243B868075EF82ED52B264BBEB","latest_block_height":"2390","latest_block_time":"2023-09-13T14:06:11.326856647Z","earliest_block_hash":"3B14843347E947941C0E1E902E1A62404866E6CF4CE304195B9032CA2973F6B0","earliest_app_hash":"E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855","earliest_block_height":"1","earliest_block_time":"2023-09-13T10:14:18.969081047Z","catching_up":false},"ValidatorInfo":{"Address":"F6613A6C5A3206774AB939BED3DA7B64CD1FBB10","PubKey":{"type":"tendermint/PubKeyEd25519","value":"1w4cB/dtQGg5mIUiJ8jMY7awbC7xfkh7lr1x66zB63E="},"VotingPower":"50"}}
```

-----

* Are the periods and thresholds right? Should they be something else?
* Should we do `agd status` instead and check the return code?