### PR TITLE
feat(node): readiness checks for nodes

### DIFF
--- a/bases/node/node.yaml
+++ b/bases/node/node.yaml
@@ -292,6 +292,29 @@ spec:
               name: prom
             - containerPort: 1317
               name: api
+          # Can we somehow detect errors that are recoverable by restarting the node?
+          # My feeling is that the only one of these would be if the daemon exits, which
+          # is already handled by normal container restarts.
+          # startupProbe:
+          #   httpGet:
+          #     path: /health
+          #     port: rpc
+          #   failureThreshold: 120
+          #   periodSeconds: 10
+          # livenessProbe:
+          #   httpGet:
+          #     path: /health
+          #     port: rpc
+          #   failureThreshold: 3
+          #   periodSeconds: 10
+          readinessProbe:
+            exec:
+              command:
+                - bash
+                - -c
+                - agd status | jq '.SyncInfo.catching_up' | grep false
+            initialDelaySeconds: 10
+            periodSeconds: 10
           volumeMounts:
             - name: state
               mountPath: /state

--- a/bases/primaryvalidator/service.yaml
+++ b/bases/primaryvalidator/service.yaml
@@ -5,6 +5,7 @@ metadata:
   name: validator-primary
 spec:
   type: ClusterIP
+  publishNotReadyAddresses: true
   selector:
     app: validator-primary
   ports:

--- a/bases/seed/service.yaml
+++ b/bases/seed/service.yaml
@@ -5,6 +5,7 @@ metadata:
   name: seed
 spec:
   type: ClusterIP
+  publishNotReadyAddresses: true
   selector:
     app: seed
   ports:

--- a/bases/shared/entrypoint.sh
+++ b/bases/shared/entrypoint.sh
@@ -700,4 +700,5 @@ esac
 if [ -f "/state/hang" ]; then
     hang
 fi
-hang
+# for debugging:
+# hang


### PR DESCRIPTION
closes: #3
closes: Agoric/instagoric-private#2

- remove unconditional call to `hang` from `entrypoint.sh` because it would allow the executed program to exit without k8s noticing the fact (which prevented automatic restart)
- the above change allows us to eschew liveness checks (since the startup probe might cause pod death due to unanticipated but normal delays in starting a node), at least until we have a clear signal of when the node is doing useful work
- add readiness check developed with @raphdev to ensure traffic is not routed to nodes that are not caught-up
- the above change alone causes a deadlock when trying to start the chain, so solve that by adding `publishNotReadyAddresses: true` to internal services used only for coordination during startup
