### PR TITLE
Add prometheus-process-exporter

### DIFF
--- a/bases/shared/entrypoint.sh
+++ b/bases/shared/entrypoint.sh
@@ -33,6 +33,33 @@ echo "/state/cores/core.%e.%p.%h.%t" > /proc/sys/kernel/core_pattern
 
 ln -sf "$SLOGFILE" /state/slogfile_current.json
 
+
+export MAX_VATS=70
+
+generate_process_metrics_exporter_config() {
+    mkdir -p /config/process-metrics
+    echo "process_names:" > /config/process-metrics/config.yaml
+    for i in $(seq 1 $MAX_VATS); do
+      echo "  - name: \"v$i\""
+      echo "    cmdline:"
+      echo "    - \".* v$i:.*\""
+      echo ""
+    done >> /config/process-metrics/config.yaml
+}
+
+start_process_metrics_exporter () {
+    (
+      while true; do
+        prometheus-process-exporter -config.path /config/process-metrics/config.yaml >> /state/process-exporter.log 2>&1
+        sleep 1
+      done
+    )
+}
+
+generate_process_metrics_exporter_config
+apt-get install -y prometheus-process-exporter
+start_process_metrics_exporter &
+
 ag_binary () {
     if [[ -z "$AG0_MODE" ]]; then 
         echo "agd";


### PR DESCRIPTION
When partners add new contracts, we would like to see how they are behaving in terms of CPU/Memory usage. Contracts run inside Vats, and we want to get these metrics from Vat processes. 

I tried getting process-level metrics by enabling them in `private-bases/telemetry/otel-config.yaml` but Otel or DD were not able to deliver all the labels to allow us to view per process metrics, and instead all xsnap-worker process instances had their metrics aggregated.

The alternative solution I am going with is to add `prometheus-process-exporter` and run it to collect process level metrics. There is a separate PR that configured DD to receive these metrics.

This PR does the following.
1. Install prometheus-process-exporter
2. Create a config of the following format.
```
process_names:
  - name: "v1"
    cmdline:
    - '.* v1:.*'
    
  - name: "v2"
    cmdline:
    - '.* v2:.*'
```
3. Run the otel exporter to extract process level metrics.

Refs:
https://github.com/Agoric/agoric-sdk/issues/8196
https://github.com/ncabatoff/process-exporter



