### PR TITLE
Store stats exporter tool

### DIFF
--- a/scripts/store-stats/package.json
+++ b/scripts/store-stats/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "store-stats",
+  "version": "1.0.0",
+  "main": "index.js",
+  "type": "module",
+  "dependencies": {
+    "@opentelemetry/api": "^1.6.0",
+    "@opentelemetry/exporter-prometheus": "^0.43.0",
+    "@opentelemetry/sdk-metrics-base": "^0.31.0",
+    "sqlite3": "^5.1.6"
+  }
+}

--- a/scripts/store-stats/package.json
+++ b/scripts/store-stats/package.json
@@ -4,9 +4,9 @@
   "main": "index.js",
   "type": "module",
   "dependencies": {
-    "@opentelemetry/api": "^1.6.0",
-    "@opentelemetry/exporter-prometheus": "^0.43.0",
+    "@opentelemetry/api": "~1.3.0",
+    "@opentelemetry/exporter-prometheus": "~0.35.0",
     "@opentelemetry/sdk-metrics-base": "^0.31.0",
-    "sqlite3": "^5.1.6"
+    "better-sqlite3": "^8.2.0"
   }
 }

--- a/scripts/store-stats/store-stats.js
+++ b/scripts/store-stats/store-stats.js
@@ -35,8 +35,10 @@ const vatstores = [];
 const db = new sqlite3.Database(dbFilePath);
 const getVatstoreStats = async () => {
   for (let id = 1; id <= MAX_VATS; id++) {
-    const query = `SELECT COUNT(*) as keyCount FROM kvStore WHERE key LIKE 'v${id}.vs.%'`;
-    await db.get(query, [], (err, row) => {
+    const query = `SELECT COUNT(*) as keyCount FROM kvStore WHERE key LIKE ?`;
+    const keyPattern = `v${id}.vs.%`;
+
+    db.get(query, [keyPattern], (err, row) => {
       if (err) {
         console.error(err.message);
         return;
@@ -86,7 +88,6 @@ function shutdown() {
 
   exporter.shutdown(() => {
     console.log('Exporter shut down. Exiting...');
-    process.exit(0);
   });
 }
 

--- a/scripts/store-stats/store-stats.js
+++ b/scripts/store-stats/store-stats.js
@@ -1,0 +1,97 @@
+/**
+ * Vatstore Metrics Tool
+ *
+ * This tool is designed to periodically gather statistics from a SwingStore SQLite database,
+ * specifically counting rows related to Vat storage. It then exposes these metrics in a format
+ * suitable for scraping by a Prometheus instance.
+ *
+ * Usage:
+ *   node <script-name> <path-to-sqlite-db> [interval-in-milliseconds]
+ *
+ * <script-name> - Name of this script.
+ * <path-to-sqlite-db> - The path to the SQLite database to be monitored.
+ * [interval-in-milliseconds] - Optional. How often to fetch data from the database. Defaults to 10 minutes.
+ */
+
+import { MeterProvider } from '@opentelemetry/sdk-metrics';
+import { PrometheusExporter } from '@opentelemetry/exporter-prometheus';
+import sqlite3 from 'sqlite3';
+
+const DB_READ_INTERVAL = 10 * 60 * 1000; // 10 minutes
+const PORT = 9184;
+const ENDPOINT = '/metrics';
+const MAX_VATS = 80;
+
+const dbFilePath = process.argv[2];
+if (!dbFilePath) {
+  console.error('SwingStore SQLite database file is required argument.');
+  process.exit(1);
+}
+
+const dbReadInterval = parseInt(process.argv[3], 10) || DB_READ_INTERVAL;
+
+const vatstores = [];
+
+const db = new sqlite3.Database(dbFilePath);
+const getVatstoreStats = async () => {
+  for (let id = 1; id <= MAX_VATS; id++) {
+    const query = `SELECT COUNT(*) as keyCount FROM kvStore WHERE key LIKE 'v${id}.vs.%'`;
+    await db.get(query, [], (err, row) => {
+      if (err) {
+        console.error(err.message);
+        return;
+      }
+      if (row.keyCount > 0) {
+        vatstores.push({ count: row.keyCount, vatId: `v${id}` });
+      }
+    });
+  }
+};
+
+const exporter = new PrometheusExporter(
+  {
+    port: PORT,
+    endpoint: ENDPOINT,
+  },
+  () => {
+    console.log(
+      `prometheus scrape endpoint: http://localhost:${PORT}${ENDPOINT}`,
+    );
+  },
+);
+
+// Creates MeterProvider and installs the exporter as a MetricReader
+const meterProvider = new MeterProvider();
+meterProvider.addMetricReader(exporter);
+const meter = meterProvider.getMeter('db-stats');
+
+const observableCounter = meter.createObservableUpDownCounter('vatstore_rows', {
+  description: 'Number of rows in the Vat storage ',
+});
+
+observableCounter.addCallback(observableResult => {
+  for (const vat of vatstores) {
+    observableResult.observe(vat.count, { vatId: vat.vatId });
+  }
+});
+
+function shutdown() {
+  console.log('Received shutdown signal. Shutting down gracefully...');
+
+  db.close(err => {
+    if (err) {
+      console.error('Error closing the database:', err.message);
+    }
+  });
+
+  exporter.shutdown(() => {
+    console.log('Exporter shut down. Exiting...');
+    process.exit(0);
+  });
+}
+
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);
+
+getVatstoreStats();
+setInterval(getVatstoreStats, dbReadInterval);


### PR DESCRIPTION
This tool is designed to periodically gather statistics from a SwingStore SQLite database, specifically counting rows related to Vat storage. It then exposes these metrics in a format suitable for scraping by a Prometheus instance.

Usage: `node store-stats.js swingstore.sqlite`

Metrics can be fetched by `curl http://localhost:9184/metrics` to get the following.
```
# HELP target_info Target metadata
# TYPE target_info gauge
target_info{service_name="unknown_service:node",telemetry_sdk_language="nodejs",telemetry_sdk_name="opentelemetry",telemetry_sdk_version="1.17.0"} 1
# HELP vatstore_rows Number of rows in the Vat storage
# TYPE vatstore_rows gauge
vatstore_rows{vatId="v1"} 325
vatstore_rows{vatId="v2"} 216
vatstore_rows{vatId="v8"} 64
vatstore_rows{vatId="v7"} 477
vatstore_rows{vatId="v6"} 333
vatstore_rows{vatId="v11"} 2430
vatstore_rows{vatId="v9"} 585721
vatstore_rows{vatId="v3"} 9
vatstore_rows{vatId="v13"} 193
vatstore_rows{vatId="v15"} 341
vatstore_rows{vatId="v16"} 1308
vatstore_rows{vatId="v5"} 130
vatstore_rows{vatId="v4"} 41
vatstore_rows{vatId="v14"} 5778
...
```
