### PR TITLE
Remove ramdisk mount from /tmp

### DIFF
--- a/bases/node/node.yaml
+++ b/bases/node/node.yaml
@@ -338,8 +338,6 @@ spec:
               mountPath: /config/server
             - name: store-stats
               mountPath: /config/store-stats
-            - name: ramdisk
-              mountPath: /tmp
           resources:
             limits:
               cpu: 1000m
@@ -452,9 +450,6 @@ spec:
         - name: store-stats
           configMap:
             name: store-stats
-        - name: ramdisk
-          emptyDir:
-            medium: Memory
   volumeClaimTemplates:
     - metadata:
         name: state

--- a/bases/shared/entrypoint.sh
+++ b/bases/shared/entrypoint.sh
@@ -46,7 +46,7 @@ echo "/state/cores/core.%e.%p.%h.%t" > /proc/sys/kernel/core_pattern
 ln -sf "$SLOGFILE" /state/slogfile_current.json
 
 
-export MAX_VATS=70
+export MAX_VATS=150
 
 generate_process_metrics_exporter_config() {
     mkdir -p /config/process-metrics
@@ -58,9 +58,9 @@ generate_process_metrics_exporter_config() {
       echo ""
     done >> /config/process-metrics/config.yaml
     echo "" >> /config/process-metrics/config.yaml
-    echo "  - name: \"node\"" >> /config/process-metrics/config.yaml
+    echo "  - name: \"agd\"" >> /config/process-metrics/config.yaml
     echo "    cmdline:" >> /config/process-metrics/config.yaml
-    echo "    - \".*node.*start.*\"" >> /config/process-metrics/config.yaml
+    echo "    - \".*ag-chain-cosmos.*\"" >> /config/process-metrics/config.yaml
     echo "" >> /config/process-metrics/config.yaml
 }
 
@@ -476,7 +476,7 @@ fork_setup() {
     persistent_peers="persistent_peers = \"0663e8221928c923d516ea1e8972927f54da9edb@$FORK1_IP:26656,e234dc7fffdea593c5338a9dd8b5c22ba00731eb@$FORK2_IP:26656\""
     sed -i "/^persistent_peers =/s/.*/$persistent_peers/" $AGORIC_HOME/config/config.toml
 
-    sed -i 's/^snapshot-interval = 0/snapshot-interval = 500/' $AGORIC_HOME/config/app.toml
+    sed -i 's/^snapshot-interval = .*/snapshot-interval = 0/' $AGORIC_HOME/config/app.toml
 
     # For importing a exported state only
     # sed -i 's/halt-height = 0/halt-height = 1/' $AGORIC_HOME/config/app.toml


### PR DESCRIPTION
- Remove tmpfs
- Add agd process stats
- Increase the number of vats to monitor

**Details on tmpfs fix:**

Fix the /tmp ramdisk issue causing crashes in Instagoric testnets, particularly noticeable post-upgrade13 on emerynet. The state-sync fix, while enabling more snapshots, inadvertently led to excessive RAM usage due to the following:

- Our validators' /tmp was set to a ramdisk-based tmpfs filesystem, directly consuming RAM for each byte written.
- Creating a state-sync snapshot involved writing 20-50 GB to /tmp/.
- This usage triggered the OOM Killer, as it counts against RAM limits but isn't reflected in most of our monitoring metrics.
- The RAM consumed by tmpfs wasn't attributed to any specific process.
- Consequently, the validator pod was terminated by the OOM Killer due to high RAM usage during snapshot operations.
- Additionally, /tmp wasn't cleared on pod restarts, reducing available RAM for subsequent launches and accelerating OOM occurrences.
- Repeated failures compounded the issue by leaving more incomplete exports in RAM.
- This PR addresses these challenges to stabilize the system.

The fix is to change our kubernetes configuration to remove the "/tmp is a separate mount with tmpfs" line. That will allow writes to /tmp to fall through to the normal (ephemeral) read-write mount that all containers get, but those writes won't contend with actual application RAM needs.