### PR TITLE
Revert volumeClaimTemplates change

### DIFF
--- a/bases/validators/kustomization.yaml
+++ b/bases/validators/kustomization.yaml
@@ -69,4 +69,4 @@ patches:
               optional: true
       - op: replace
         path: /spec/volumeClaimTemplates/0/spec/resources/requests/storage
-        value: 500Gi
+        value: 300Gi


### PR DESCRIPTION
This limit was increased few days ago for mainfork where usually we destroy the instagoric namespace including the persistent volumes, before we deploy the instagoric changes. This volumeClaimTemplates change requires deleting the old state before it can be deployed because it needs to create a new state volume. 
But on other testnets, where we usually want to keep the state in tact, this change does not install properly if persistent volume is not deleted first. 
 