### PR TITLE
feat: make instagoric independent of namespace name

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Optionally specify the Agoric SDK image tag.
 
 To deploy:
 
-1. kubectl apply -k .
+1. kubectl -n instagoric apply -k .
 
 When finished:
 

--- a/bases/primaryvalidator/kustomization.yaml
+++ b/bases/primaryvalidator/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: instagoric
+# namespace: instagoric
 
 resources:
   - ../node

--- a/bases/rpcnodes/service.yaml
+++ b/bases/rpcnodes/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: cloud.google.com/v1
 kind: BackendConfig
 metadata:
-  name: stage-grpc-backendconfig
+  name: grpc-backendconfig
 spec:
   healthCheck:
     port: 8080
@@ -11,11 +11,21 @@ spec:
 apiVersion: cloud.google.com/v1
 kind: BackendConfig
 metadata:
-  name: stage-api-backendconfig
+  name: api-backendconfig
 spec:
   healthCheck:
     port: 1317
     requestPath: /node_info
+    type: HTTP
+---
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: rpc-backendconfig
+spec:
+  healthCheck:
+    port: 26657
+    requestPath: /abci_info
     type: HTTP
 ---
 apiVersion: v1
@@ -24,7 +34,7 @@ metadata:
   name: rpcnodes
   annotations:
     cloud.google.com/app-protocols: '{"grpc":"HTTP2"}'
-    cloud.google.com/backend-config: '{"ports":{"grpc":"stage-grpc-backendconfig","api":"stage-api-backendconfig"}}'
+    cloud.google.com/backend-config: '{"ports":{"grpc":"grpc-backendconfig","api":"api-backendconfig","rpc":"rpc-backendconfig"}}'
     cloud.google.com/neg: '{"ingress":true,"exposed_ports":{"26657":{},"1317":{},"9090":{},"8001":{}}}'
 spec:
   type: ClusterIP

--- a/bases/shared/instagoric-server/package.json
+++ b/bases/shared/instagoric-server/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "exit 0",
     "test": "exit 0",
-    "start": "NAMESPACE=instagoric node server.js",
+    "start": "NAMESPACE=${NAMESPACE-instagoric} node server.js",
     "test:c8": "c8 $C8_OPTIONS ava --config=ava-nesm.config.js",
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",

--- a/bases/shared/instagoric-server/server.js
+++ b/bases/shared/instagoric-server/server.js
@@ -146,7 +146,7 @@ const getNetworkConfig = async () => {
   ap.peers[0] = ap.peers[0].replace(
     'validator-primary.instagoric.svc.cluster.local',
     svc.get('validator-primary-ext') ||
-      `${podname}.instagoric.svc.cluster.local`,
+      `${podname}.${namespace}.svc.cluster.local`,
   );
   ap.peers[0] = ap.peers[0].replace(
     'fb86a0993c694c981a28fa1ebd1fd692f345348b', `${NODE_ID}`,
@@ -156,7 +156,7 @@ const getNetworkConfig = async () => {
   if (INCLUDE_SEED==='yes') {
     ap.seeds[0] = ap.seeds[0].replace(
       'seed.instagoric.svc.cluster.local',
-      svc.get('seed-ext') || 'seed.instagoric.svc.cluster.local',
+      svc.get('seed-ext') || `seed.${namespace}.svc.cluster.local`,
     );
   } else {
     ap.seeds = [];

--- a/bases/shared/serviceaccount.yaml
+++ b/bases/shared/serviceaccount.yaml
@@ -32,7 +32,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: opentracing-agent
-  namespace: instagoric
+  # namespace: instagoric
 roleRef:
   kind: ClusterRole
   name: opentracing-agent

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: instagoric
+# namespace: instagoric
 
 resources:
   - overlays/local

--- a/overlays/ag0/kustomization.yaml
+++ b/overlays/ag0/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: instagoric
+# namespace: instagoric
 
 resources:
   - ../../bases/shared

--- a/overlays/follower/kustomization.yaml
+++ b/overlays/follower/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: instagoric
+# namespace: instagoric
 
 resources:
   - ../../bases/shared

--- a/overlays/fork/kustomization.yaml
+++ b/overlays/fork/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: instagoric
+# namespace: instagoric
 
 resources:
   - ../../bases/shared

--- a/overlays/local/kustomization.yaml
+++ b/overlays/local/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: instagoric
+# namespace: instagoric
 
 resources:
   - ../../bases/shared

--- a/overlays/testnet/kustomization.yaml
+++ b/overlays/testnet/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: instagoric
+# namespace: instagoric
 
 resources:
   - ../../bases/shared

--- a/scripts/kagd.sh
+++ b/scripts/kagd.sh
@@ -47,7 +47,7 @@ if [[ "$1" == "--all" ]]; then
   shift
   targets=
   for label in validator validator-primary; do
-    targets="$targets $(kubectl -n instagoric get -l app=$label pods -o jsonpath='{.items[*].metadata.name}')"
+    targets="$targets $(kubectl get -l app=$label pods -o jsonpath='{.items[*].metadata.name}')"
   done
 else
   targets="validator-primary-0"
@@ -66,5 +66,5 @@ case $1 in
 esac
 
 for v in $targets; do
-  kubectl -n instagoric exec "$v" -- agd --home="/state/$chainid" ${1+"$@"}
+  kubectl exec "$v" -- agd --home="/state/$chainid" ${1+"$@"}
 done


### PR DESCRIPTION
Don't explicitly pass `-n instagoric`... let the user set proper config like `kubectl config set-context --current --namespace=<ns>`.

This allows for multiple Instagoric namespaces per cluster.
