### PR TITLE
Fix disk sizes and add rpcnodes in follower

### DIFF
--- a/bases/follower/kustomization.yaml
+++ b/bases/follower/kustomization.yaml
@@ -68,4 +68,4 @@ patches:
               optional: true
       - op: replace
         path: /spec/volumeClaimTemplates/0/spec/resources/requests/storage
-        value: 300Gi
+        value: 1000Gi

--- a/bases/primaryvalidator/kustomization.yaml
+++ b/bases/primaryvalidator/kustomization.yaml
@@ -68,5 +68,5 @@ patches:
               optional: true
       - op: replace
         path: /spec/volumeClaimTemplates/0/spec/resources/requests/storage
-        value: 300Gi
+        value: 1000Gi
   

--- a/bases/seed/kustomization.yaml
+++ b/bases/seed/kustomization.yaml
@@ -44,4 +44,4 @@ patches:
         value: seed-ext
       - op: replace
         path: /spec/volumeClaimTemplates/0/spec/resources/requests/storage
-        value: 300Gi
+        value: 1000Gi

--- a/bases/shared/entrypoint.sh
+++ b/bases/shared/entrypoint.sh
@@ -31,7 +31,7 @@ export DD_AGENT_HOST=datadog.datadog.svc.cluster.local
 export MAINFORK_HEIGHT=13512995
 export MAINFORK_IMAGE_URL="https://storage.googleapis.com/agoric-snapshots-public/mainfork-snapshots"
 
-export MAINNET_SNAPSHOT="agoric_14297487.tar.lz4"
+export MAINNET_SNAPSHOT="agoric_14538863.tar.lz4"
 export MAINNET_SNAPSHOT_URL="https://snapshots.polkachu.com/snapshots/agoric"
 export MAINNET_ADDRBOOK_URL="https://snapshots.polkachu.com/addrbook/agoric/addrbook.json"
 export TMPDIR=/state/tmp

--- a/bases/validators/kustomization.yaml
+++ b/bases/validators/kustomization.yaml
@@ -69,4 +69,4 @@ patches:
               optional: true
       - op: replace
         path: /spec/volumeClaimTemplates/0/spec/resources/requests/storage
-        value: 300Gi
+        value: 1000Gi

--- a/overlays/follower/kustomization.yaml
+++ b/overlays/follower/kustomization.yaml
@@ -5,4 +5,5 @@ kind: Kustomization
 resources:
   - ../../bases/shared
   - ../../bases/follower
+  - ../../bases/rpcnodes
   - ../../bases/explorer


### PR DESCRIPTION
We have manually updated the disk space of most clusters so the disk update here is needed for future deployment.
To expose RPC ports, we need to add rpcnodes service in the followers.