### PR TITLE
Revert disk space increase of emerynet

### DIFF
--- a/bases/primaryvalidator/kustomization.yaml
+++ b/bases/primaryvalidator/kustomization.yaml
@@ -68,5 +68,5 @@ patches:
               optional: true
       - op: replace
         path: /spec/volumeClaimTemplates/0/spec/resources/requests/storage
-        value: 1000Gi
+        value: 300Gi
   

--- a/bases/seed/kustomization.yaml
+++ b/bases/seed/kustomization.yaml
@@ -44,4 +44,4 @@ patches:
         value: seed-ext
       - op: replace
         path: /spec/volumeClaimTemplates/0/spec/resources/requests/storage
-        value: 1000Gi
+        value: 300Gi

--- a/bases/validators/kustomization.yaml
+++ b/bases/validators/kustomization.yaml
@@ -69,4 +69,4 @@ patches:
               optional: true
       - op: replace
         path: /spec/volumeClaimTemplates/0/spec/resources/requests/storage
-        value: 1000Gi
+        value: 300Gi


### PR DESCRIPTION
We manually increased the persistence disk space of emerynet. Replacing it in the config does not match with existing config, causing deployment to fail. Reverting this increase to make sure that we can deploy emerynet.