### PR TITLE
Remove process metrics reporting

### DIFF
--- a/bases/shared/entrypoint.sh
+++ b/bases/shared/entrypoint.sh
@@ -51,38 +51,6 @@ echo "/state/cores/core.%e.%p.%h.%t" > /proc/sys/kernel/core_pattern
 
 ln -sf "$SLOGFILE" /state/slogfile_current.json
 
-
-export MAX_VATS=150
-
-generate_process_metrics_exporter_config() {
-    mkdir -p /config/process-metrics
-    echo "process_names:" > /config/process-metrics/config.yaml
-    for i in $(seq 1 $MAX_VATS); do
-      echo "  - name: \"v$i\""
-      echo "    cmdline:"
-      echo "    - \".* v$i:.*\""
-      echo ""
-    done >> /config/process-metrics/config.yaml
-    echo "" >> /config/process-metrics/config.yaml
-    echo "  - name: \"agd\"" >> /config/process-metrics/config.yaml
-    echo "    cmdline:" >> /config/process-metrics/config.yaml
-    echo "    - \".*ag-chain-cosmos.*\"" >> /config/process-metrics/config.yaml
-    echo "" >> /config/process-metrics/config.yaml
-}
-
-start_process_metrics_exporter () {
-    (
-      while true; do
-        prometheus-process-exporter -config.path /config/process-metrics/config.yaml >> /state/process-exporter.log 2>&1
-        sleep 120
-      done
-    )
-}
-
-generate_process_metrics_exporter_config
-apt-get install -y prometheus-process-exporter
-start_process_metrics_exporter &
-
 install_store_stats_exporter() {
     mkdir -p $HOME/store-stats
     cp /config/store-stats/* $HOME/store-stats


### PR DESCRIPTION
We already have process metrics in Datadog through K8 + datadog magic integration but we were not able to see them before because we didn't know how to expose them in datadog.

https://us3.datadoghq.com/process?selectedTopGraph=timeseries
The above URL shows the processes-related metrics. We have added a graph in the dashboard that uses Processes but the metrics are only retained for 36 hours. There is a way to increase that retention by creating custom metrics based on Process metrics that we should try.

After this change is deployed, then some of the memory/cpu graphs will be turned off in the testnet dashboards. We will also lose the total Vats graph because that depends on these metrics being removed. Later we should find a way to show the running Vat process number using custom metrics depending on the Process metric.