### PR TITLE
Periodically restart pods

### DIFF
--- a/bases/shared/cron.sh
+++ b/bases/shared/cron.sh
@@ -13,7 +13,7 @@ apt-get install cron --yes > /dev/null
 touch "$CRON_FILE_PATH" "$CRON_LOGS_FILE_PATH"
 
 cat <<EOF >> "$CRON_FILE_PATH"
-0 */6 * * * $(whoami) export ROLE="$ROLE" && $(which bash) $DIRECTORY_PATH/restart-pods.sh > "$CRON_LOGS_FILE_PATH" 2>&1
+0 0 * * * $(whoami) export ROLE="$ROLE" && $(which bash) $DIRECTORY_PATH/restart-pods.sh > "$CRON_LOGS_FILE_PATH" 2>&1
 
 EOF
 

--- a/bases/shared/cron.sh
+++ b/bases/shared/cron.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -eux
+
+DIRECTORY_PATH="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+CRON_FILE_PATH=/etc/cron.d/restart-pods
+CRON_LOGS_FILE_PATH=/state/cron.logs
+
+apt-get update --yes > /dev/null
+apt-get install cron --yes > /dev/null
+
+touch "$CRON_FILE_PATH" "$CRON_LOGS_FILE_PATH"
+
+cat <<EOF >> "$CRON_FILE_PATH"
+0 */6 * * * $(whoami) export ROLE="$ROLE" && $(which bash) $DIRECTORY_PATH/restart-pods.sh > "$CRON_LOGS_FILE_PATH" 2>&1
+
+EOF
+
+cron -L 15

--- a/bases/shared/entrypoint.sh
+++ b/bases/shared/entrypoint.sh
@@ -870,6 +870,7 @@ case "$ROLE" in
             ( wait_till_syncup_and_fund ) &
         fi
 
+        /bin/bash /entrypoint/cron.sh
         start_chain
         ;;
 
@@ -994,6 +995,8 @@ case "$ROLE" in
             sed -i 's/^snapshot-interval = .*/snapshot-interval = 0/' $AGORIC_HOME/config/app.toml
             touch /state/follower-initialized
         fi
+
+        /bin/bash /entrypoint/cron.sh
 
         export DEBUG="agoric,SwingSet:ls,SwingSet:vat"
         start_chain

--- a/bases/shared/entrypoint.sh
+++ b/bases/shared/entrypoint.sh
@@ -967,6 +967,9 @@ case "$ROLE" in
     "fork1")
         (WHALE_KEYNAME=whale POD_NAME=fork1 SEED_ENABLE=no NODE_ID='0663e8221928c923d516ea1e8972927f54da9edb' start_helper &)
         fork_setup agoric1
+
+        /bin/bash /entrypoint/cron.sh
+
         export DEBUG="agoric,SwingSet:ls,SwingSet:vat"
         start_chain --iavl-disable-fastnode false
         ;;

--- a/bases/shared/kustomization.yaml
+++ b/bases/shared/kustomization.yaml
@@ -13,7 +13,9 @@ configMapGenerator:
       - resources/economy-proposals.json
   - name: entrypoint
     files:
+      - cron.sh
       - entrypoint.sh
+      - restart-pods.sh
   - name: server
     files:
       - instagoric-server/lockdown.js

--- a/bases/shared/restart-pods.sh
+++ b/bases/shared/restart-pods.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+set -eux
+
+CERTIFICATE_FILE=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+NAMESPACE=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
+OUTPUT_FILE="/tmp/$(date '+%s').json"
+TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+
+cleanup() {
+    rm --force "$OUTPUT_FILE"
+}
+
+delete_pod() {
+    local POD_NAME="$1"
+    echo "Deleting pod $POD_NAME"
+
+    curl "https://kubernetes.default.svc/api/v1/namespaces/$NAMESPACE/pods/$POD_NAME" \
+     --cacert "$CERTIFICATE_FILE" \
+     --header "Authorization: Bearer $TOKEN" \
+     --header "Content-Type: application/json" \
+     --request DELETE 2>/dev/null
+}
+
+delete_pods() {
+    for pod_name in "${LINKED_PODNAMES[@]}"; do
+        delete_pod "$pod_name"
+        sleep 300
+    done
+    delete_pod "$CURRENT_PODNAME"
+}
+
+extract_pod_names() {
+    CURRENT_PODNAME=$(
+        jq '.items[] | select(.metadata.ownerReferences[].kind == "StatefulSet") | select(.metadata.ownerReferences[].name == $EXCLUDE_POD) | .metadata.name' \
+        --arg EXCLUDE_POD "$ROLE" --raw-output < "$OUTPUT_FILE"
+    )
+
+    # shellcheck disable=SC2207
+    LINKED_PODNAMES=($(
+        jq '.items[] | select(.metadata.ownerReferences[].kind == "StatefulSet") | select(.metadata.ownerReferences[].name != $EXCLUDE_POD) | .metadata.name' \
+        --arg EXCLUDE_POD "$ROLE" --raw-output < "$OUTPUT_FILE"
+    ))
+}
+
+get_all_pods_data() {
+    curl "https://kubernetes.default.svc/api/v1/namespaces/$NAMESPACE/pods" \
+     --cacert "$CERTIFICATE_FILE" \
+     --header "Authorization: Bearer $TOKEN" \
+     --header "Content-Type: application/json" \
+     --output "$OUTPUT_FILE" \
+     --request GET 2>/dev/null
+}
+
+get_all_pods_data
+extract_pod_names
+delete_pods
+cleanup

--- a/bases/shared/restart-pods.sh
+++ b/bases/shared/restart-pods.sh
@@ -3,6 +3,7 @@
 set -eux
 
 CERTIFICATE_FILE=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+INTERVAL=$((60 * 60))
 NAMESPACE=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
 OUTPUT_FILE="/tmp/$(date '+%s').json"
 TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
@@ -25,7 +26,7 @@ delete_pod() {
 delete_pods() {
     for pod_name in "${LINKED_PODNAMES[@]}"; do
         delete_pod "$pod_name"
-        sleep 300
+        sleep "$INTERVAL"
     done
     delete_pod "$CURRENT_PODNAME"
 }

--- a/bases/shared/serviceaccount.yaml
+++ b/bases/shared/serviceaccount.yaml
@@ -23,7 +23,7 @@ rules:
   - replicasets
   - services
   - statefulsets
-  verbs: ["get", "list", "watch"]
+  verbs: ["delete", "get", "list", "watch"]
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -32,7 +32,6 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: opentracing-agent
-  # namespace: instagoric
 roleRef:
   kind: ClusterRole
   name: opentracing-agent

--- a/bases/shared/serviceaccount.yaml
+++ b/bases/shared/serviceaccount.yaml
@@ -24,14 +24,18 @@ rules:
   - services
   - statefulsets
   verbs: ["delete", "get", "list", "watch"]
+
 ---
+
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: opentracing-agent
+  namespace: ${namespace}
 subjects:
 - kind: ServiceAccount
   name: opentracing-agent
+  namespace: ${namespace}
 roleRef:
   kind: ClusterRole
   name: opentracing-agent


### PR DESCRIPTION
## Description
This PR enables pods periodic restarts (every 6 hours). The motivation for this change is to keep the log files size in check. Restarting the pods will start a new log file and will remove the old log file (after backup) which will keep the persistent volume usage low.
The flow is added for only `validator-primary` and `follower` pods. These pods will first restart all the other (statefulset) pods in the namespace with a 5 minute gaps (so that at most one validator node is restarted) and will finally restart itself.