### PR TITLE
chore: update logs link text to 'Click Here' for clarity

### DIFF
--- a/bases/shared/instagoric-server/server.js
+++ b/bases/shared/instagoric-server/server.js
@@ -286,8 +286,8 @@ gRPC: <a href="https://${netname}.grpc${domain}">https://${netname}.grpc${domain
 API: <a href="https://${netname}.api${domain}">https://${netname}.api${domain}</a>
 Explorer: <a href="https://${netname}.explorer${domain}">https://${netname}.explorer${domain}</a>
 Faucet: <a href="https://${netname}.faucet${domain}">https://${netname}.faucet${domain}</a>
-Logs: <a href=${logsUrl}>https://monitor${domain}</a>
-Monitoring Dashboard: <a href=${dashboardUrl}>https://monitor${domain}</a>
+Logs: <a href=${logsUrl}>Click Here</a>
+Monitoring Dashboard: <a href=${dashboardUrl}>Click Here</a>
 VStorage: <a href="https://vstorage.agoric.net/?path=&endpoint=https://${netname === 'followmain' ? 'main-a' : netname}.rpc.agoric.net">https://vstorage.agoric.net/?endpoint=https://${netname === 'followmain' ? 'main-a' : netname}.rpc.agoric.net</a>
 
 UIs:


### PR DESCRIPTION
The PR revises the `<a>` tag content for clarity. Previously, the link text suggested a dashboard destination, but the `href` actually directed users to the logs, creating confusion. 

<img width="503" alt="image" src="https://github.com/user-attachments/assets/0ae4c215-49db-448b-bb07-b4ff468bc6d7">
