### PR TITLE
chore: css changes to make scrollbar/scrolling evident on screen

### DIFF
--- a/bases/shared/instagoric-server/server.js
+++ b/bases/shared/instagoric-server/server.js
@@ -627,16 +627,18 @@ faucetapp.get('/', async (req, res) => {
     <style>
       
       .dropdown {
-      overflow: scroll;
-      height: 120px;
-      width: fit-content;
+        overflow: scroll;
+        height: 120px;
+        width: fit-content;
       }
 
       .dropdown-content {
         display: block;
         background-color: #f9f9f9;
-        min-width: 160px;
-        box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+        min-width: 160px; 
+        border: 1px solid #ccc;
+        padding: 10px;
+        box-shadow: 0px 8px 16px rgba(0, 0, 0, 0.2);
       }
 
       .dropdown-content label {


### PR DESCRIPTION
During development on #69, I encountered an issue where ATOM's A3P denom was not visibly selectable via the 'Custom Denom' button on the A3P wallet interface. 

Initially, the token seemed missing from the options, leading me to hardcode the denom for testing purposes. However, I later discovered that the denomination was indeed present but not immediately visible due to the absence of a scroll effect on the UI. 

This PR introduces CSS improvements to enhance the visibility of the scrollbar, making it evident that multiple denomination options are available for selection. 


https://github.com/user-attachments/assets/a70a564f-2940-4114-8ceb-d00e8182ad86

