### PR TITLE
Fix missing CLUSTER NAME

### DIFF
--- a/bases/node/node.yaml
+++ b/bases/node/node.yaml
@@ -297,6 +297,8 @@ spec:
                   name: otel-config
                   key: OTEL_EXPORTER_OTLP_ENDPOINT
                   optional: true
+            - name: CLUSTER_NAME
+              value: "$CLUSTER_NAME"
           ports:
             - containerPort: 26656
               name: p2p


### PR DESCRIPTION
## Description
The refactor of entrypoint script zips all the scripts before uploading due to which the `envsubst` in `init.sh` couldn't replace `CLUSTER_NAME` usage in the scripts. This PR adds the `CLUSTER_NAME` as env var in `node` yaml