### PR TITLE
fix: Seed node persistent peers

### DIFF
--- a/bases/shared/scripts/main.sh
+++ b/bases/shared/scripts/main.sh
@@ -721,22 +721,38 @@ case "$ROLE" in
     ag-solo setup -v --netconfig=file:///state/network_info.json --webhost=0.0.0.0 >>/state/agsolo.log 2>&1
     ;;
 "seed")
+    primary_node_id="$(primary_node_peer)"
+    seed_node_id="$(seed_node_peer)"
+
+    primary_validator_external_address="$(get_ips "validator-primary-ext")"
+    seed_external_address="$(get_ips "seed-ext")"
+
+    PEERS="$primary_node_id@$primary_validator_external_address:26656"
+    SEEDS="$seed_node_id@$seed_external_address:26656"
+
     (WHALE_KEYNAME=$(get_whale_keyname) start_helper &)
     if [[ $firstboot == "true" ]]; then
         create_self_key
-        # wait for network live
 
-        cp /config/network/seed_node_key.json "$AGORIC_HOME/config/node_key.json"
-        # get primary peer id
-        primary=$(primary_node_peer)
-        PEERS="$primary@validator-primary.$NAMESPACE.svc.cluster.local:26656"
+        cp "/config/network/seed_node_key.json" "$AGORIC_HOME/config/node_key.json"
 
-        sed -i.bak -e "s/^seeds =.*/seeds = \"$SEEDS\"/; s/^persistent_peers =.*/persistent_peers = \"$PEERS\"/" "$AGORIC_HOME/config/config.toml"
-        sed -i.bak "s/^unconditional_peer_ids =.*/unconditional_peer_ids = \"$primary\"/" "$AGORIC_HOME/config/config.toml"
-        sed -i.bak "s/^seed_mode =.*/seed_mode = true/" "$AGORIC_HOME/config/config.toml"
+        sed "$AGORIC_HOME/config/config.toml" \
+         --expression "s|^seeds = .*|seeds = '$SEEDS'|" \
+         --in-place.bak
+        sed "$AGORIC_HOME/config/config.toml" \
+         --expression "s|^unconditional_peer_ids = .*|unconditional_peer_ids = '$primary_node_id'|" \
+         --in-place.bak
+        sed "$AGORIC_HOME/config/config.toml" \
+         --expression "s|^seed_mode = .*|seed_mode = true|" \
+         --in-place.bak
     fi
-    external_address=$(get_ips seed-ext)
-    sed -i.bak "s/^external_address =.*/external_address = \"$external_address:26656\"/" "$AGORIC_HOME/config/config.toml"
+
+    sed "$AGORIC_HOME/config/config.toml" \
+     --expression "s|^persistent_peers = .*|persistent_peers = '$PEERS'|" \
+     --in-place.bak
+    sed "$AGORIC_HOME/config/config.toml" \
+     --expression "s|^external_address = .*|external_address = '$seed_external_address:26656'|" \
+     --in-place.bak
 
     # Must not run state-sync unless we have enough non-pruned state for it.
     sed -i.bak '/^\[state-sync]/,/^\[/{s/^snapshot-interval[[:space:]]*=.*/snapshot-interval = 0/}' "$AGORIC_HOME/config/app.toml"


### PR DESCRIPTION
## Description
The seed node was using Cluster IP of primary validator as it's persistent peer. While it worked for the seed node as it was able to connect to it, any external node who was relayed this IP couldn't connect to the primary validator
The load balancer ip of the primary validator serivce is now usedr as persistent peer of seed node which is visible to external nodes