### PR TITLE
fix(Explorer): Incorrect rpc/api url in chain info for Keplr wallet connection

### DIFF
--- a/bases/explorer/config.patch
+++ b/bases/explorer/config.patch
@@ -21,3 +21,58 @@ index bf29393..5acd46f 100755
 +    },
 +  },
  });
+diff --git a/src/stores/useDashboard.ts b/src/stores/useDashboard.ts
+index 8354c17b..48074718 100644
+--- a/src/stores/useDashboard.ts
++++ b/src/stores/useDashboard.ts
+@@ -65,7 +65,9 @@ export interface ChainConfig {
+   features?: string[]
+   endpoints: {
+     rest?: Endpoint[];
++    restDirect?: Endpoint[];
+     rpc?: Endpoint[];
++    rpcDirect?: Endpoint[];
+     grpc?: Endpoint[];
+   };
+   logo: string;
+@@ -99,6 +101,7 @@ export interface LocalConfig {
+   consensus_prefix?: string;
+   alias: string;
+   api: string[] | Endpoint[];
++  apiDirect?: string[] | Endpoint[];
+   grpc: Endpoint[];
+   provider_chain: {
+     api: string[] | Endpoint[]
+@@ -116,6 +119,7 @@ export interface LocalConfig {
+   theme_color?: string;
+   min_tx_fee: string;
+   rpc: string[] | Endpoint[];
++  rpcDirect?: string[] | Endpoint[];
+   sdk_version: string;
+   registry_name?: string;
+   features?: string[];
+@@ -176,7 +180,9 @@ export function fromLocal(lc: LocalConfig): ChainConfig {
+   conf.prettyName = lc.registry_name || lc.chain_name;
+   conf.endpoints = {
+     rest: apiConverter(lc.api),
++    restDirect: apiConverter(lc.apiDirect || lc.api),
+     rpc: apiConverter(lc.rpc),
++    rpcDirect: apiConverter(lc.rpcDirect || lc.rpc),
+     grpc: apiConverter(lc.grpc),
+   };
+   if(lc.provider_chain) {
+diff --git a/src/modules/wallet/keplr.vue b/src/modules/wallet/keplr.vue
+index c8ce25b8..9aeaa079 100644
+--- a/src/modules/wallet/keplr.vue
++++ b/src/modules/wallet/keplr.vue
+@@ -32,8 +32,8 @@ async function initParamsForKeplr() {
+     conf.value = JSON.stringify({
+         chainId: chainid,
+         chainName: chain.chainName,
+-        rpc: chain.endpoints?.rpc?.at(0)?.address,
+-        rest: chain.endpoints?.rest?.at(0)?.address,
++        rpc: chain.endpoints?.rpcDirect?.at(0)?.address || chain.endpoints?.rpc?.at(0)?.address,
++        rest: chain.endpoints?.restDirect?.at(0)?.address || chain.endpoints?.rest?.at(0)?.address,
+         bip44: {
+             coinType: Number(chain.coinType),
+         },

--- a/bases/explorer/config.patch
+++ b/bases/explorer/config.patch
@@ -62,17 +62,96 @@ index 8354c17b..48074718 100644
    };
    if(lc.provider_chain) {
 diff --git a/src/modules/wallet/keplr.vue b/src/modules/wallet/keplr.vue
-index c8ce25b8..9aeaa079 100644
+index c8ce25b8..b7099fdc 100644
 --- a/src/modules/wallet/keplr.vue
 +++ b/src/modules/wallet/keplr.vue
-@@ -32,8 +32,8 @@ async function initParamsForKeplr() {
+@@ -18,8 +18,9 @@ onMounted(() => {
+ })
+ async function initParamsForKeplr() {
+     const chain = selected.value
+-    if(!chain.endpoints?.rest?.at(0)) throw new Error("Endpoint does not set");
+-    const client = CosmosRestClient.newDefault(chain.endpoints.rest?.at(0)?.address || "")
++    const restEndpoint = chain.endpoints?.restDirect?.at(0)?.address || chain.endpoints?.rest?.at(0)?.address;
++    if(!restEndpoint) throw new Error("Endpoint does not set");
++    const client = CosmosRestClient.newDefault(restEndpoint)
+     const b = await client.getBaseBlockLatest()   
+     const chainid = b.block.header.chain_id
+ 
+@@ -32,8 +33,8 @@ async function initParamsForKeplr() {
      conf.value = JSON.stringify({
          chainId: chainid,
          chainName: chain.chainName,
 -        rpc: chain.endpoints?.rpc?.at(0)?.address,
 -        rest: chain.endpoints?.rest?.at(0)?.address,
 +        rpc: chain.endpoints?.rpcDirect?.at(0)?.address || chain.endpoints?.rpc?.at(0)?.address,
-+        rest: chain.endpoints?.restDirect?.at(0)?.address || chain.endpoints?.rest?.at(0)?.address,
++        rest: restEndpoint,
+         bip44: {
+             coinType: Number(chain.coinType),
+         },
+diff --git a/src/modules/wallet/suggest.vue b/src/modules/wallet/suggest.vue
+index 5ecc76f2..415e8876 100644
+--- a/src/modules/wallet/suggest.vue
++++ b/src/modules/wallet/suggest.vue
+@@ -37,8 +37,9 @@ function onchange() {
+ 
+ async function initParamsForKeplr() {
+     const chain = selected.value
+-    if(!chain.endpoints?.rest?.at(0)) throw new Error("Endpoint does not set");
+-    const client = CosmosRestClient.newDefault(chain.endpoints.rest?.at(0)?.address || "")
++    const restEndpoint = chain.endpoints?.restDirect?.at(0)?.address || chain.endpoints?.rest?.at(0)?.address;
++    if(!restEndpoint) throw new Error("Endpoint does not set");
++    const client = CosmosRestClient.newDefault(restEndpoint)
+     const b = await client.getBaseBlockLatest()   
+     const chainid = b.block.header.chain_id
+ 
+@@ -51,8 +52,8 @@ async function initParamsForKeplr() {
+     conf.value = JSON.stringify({
+         chainId: chainid,
+         chainName: chain.chainName,
+-        rpc: chain.endpoints?.rpc?.at(0)?.address,
+-        rest: chain.endpoints?.rest?.at(0)?.address,
++        rpc: chain.endpoints?.rpcDirect?.at(0)?.address || chain.endpoints?.rpc?.at(0)?.address,
++        rest: restEndpoint,
+         bip44: {
+             coinType: Number(chain.coinType),
+         },
+@@ -96,9 +97,10 @@ async function initParamsForKeplr() {
+ async function initSnap() {
+     const chain = selected.value
+     const [token] = chain.assets
++    const restEndpoint = chain.endpoints?.restDirect?.at(0)?.address || chain.endpoints?.rest?.at(0)?.address;
+ 
+-    if(!chain.endpoints?.rest?.at(0)) throw new Error("Endpoint does not set");
+-    const client = CosmosRestClient.newDefault(chain.endpoints.rest?.at(0)?.address || "")
++    if(!restEndpoint) throw new Error("Endpoint does not set");
++    const client = CosmosRestClient.newDefault(restEndpoint)
+     const b = await client.getBaseBlockLatest()   
+     const chainId = b.block.header.chain_id
+ 
+diff --git a/src/modules/wallet/unisat.vue b/src/modules/wallet/unisat.vue
+index 2a04d56a..32d9b98e 100644
+--- a/src/modules/wallet/unisat.vue
++++ b/src/modules/wallet/unisat.vue
+@@ -16,8 +16,9 @@ onMounted(() => {
+ })
+ async function initParamsForKeplr() {
+     const chain = selected.value
+-    if(!chain.endpoints?.rest?.at(0)) throw new Error("Endpoint does not set");
+-    const client = CosmosRestClient.newDefault(chain.endpoints.rest?.at(0)?.address || "")
++    const restEndpoint = chain.endpoints?.restDirect?.at(0)?.address || chain.endpoints?.rest?.at(0)?.address;
++    if(!restEndpoint) throw new Error("Endpoint does not set");
++    const client = CosmosRestClient.newDefault(restEndpoint)
+     const b = await client.getBaseBlockLatest()   
+     const chainid = b.block.header.chain_id
+ 
+@@ -30,8 +31,8 @@ async function initParamsForKeplr() {
+     conf.value = JSON.stringify({
+         chainId: chainid,
+         chainName: chain.chainName,
+-        rpc: chain.endpoints?.rpc?.at(0)?.address,
+-        rest: chain.endpoints?.rest?.at(0)?.address,
++        rpc: chain.endpoints?.rpcDirect?.at(0)?.address || chain.endpoints?.rpc?.at(0)?.address,
++        rest: restEndpoint,
          bip44: {
              coinType: Number(chain.coinType),
          },

--- a/bases/explorer/entrypoint.sh
+++ b/bases/explorer/entrypoint.sh
@@ -3,6 +3,7 @@
 set -o errexit -o nounset
 
 COMMIT_HASH="4d2d093560c52e08458f97f451dc1f0690e00094"
+NETDOMAIN="${NETDOMAIN:-".agoric.net"}"
 PING_PUB_REPOSITORY_LINK="https://github.com/ping-pub/explorer.git"
 PING_PUB_SOURCE="/workspace"
 SERVER_PORT="8080"
@@ -21,7 +22,7 @@ copy_logos() {
 set_chain_data() {
   rm --force $PING_PUB_SOURCE/chains/mainnet/*.json $PING_PUB_SOURCE/chains/testnet/*.json
 
-  jq '.api[] = "/api" | .rpc[] = "/rpc"' \
+  jq ".api[] = \"/api\" | .apiDirect = [\"https://$NETNAME.api$NETDOMAIN\"] | .rpc[] = \"/rpc\" | .rpcDirect = [\"https://$NETNAME.rpc$NETDOMAIN\"]" \
     --raw-output \
     <"/entrypoint/agoric.json" >"$PING_PUB_SOURCE/chains/mainnet/agoric.json"
 }

--- a/bases/explorer/explorer.yaml
+++ b/bases/explorer/explorer.yaml
@@ -17,6 +17,18 @@ spec:
       containers:
         - args: ["/entrypoint/entrypoint.sh"]
           command: ["/bin/bash"]
+          env:
+            - name: NETNAME
+              valueFrom:
+                configMapKeyRef:
+                  key: NETNAME
+                  name: instagoric-release
+            - name: NETDOMAIN
+              valueFrom:
+                configMapKeyRef:
+                  key: NETDOMAIN
+                  optional: true
+                  name: instagoric-release
           image: "node:20-bullseye"
           name: explorer
           ports:


### PR DESCRIPTION
## Description
This PR fixes a regression of https://github.com/Agoric/instagoric/pull/96
When connecting the wallet with chain, the generated chain info has `/api` and `/rpc` urls instead of the actual rpc and api urls. This PR adds a patch to use the appropriate urls for the chain info
Verify that suggesting chain from https://emerynet.explorer.agoric.net/wallet/suggest will not work but https://usman.explorer.agoric.net/wallet/suggest should