### PR TITLE
fix(instagoric): Voting_Period inside gov params after 0.50

### DIFF
--- a/bases/shared/scripts/util.sh
+++ b/bases/shared/scripts/util.sh
@@ -389,6 +389,7 @@ initialize_new_chain() {
                 .app_state.mint.params.inflation_rate_change = "0.000000000000000000" |
                 .app_state.mint.params.inflation_min = "0.000000000000000000" |
                 .app_state.mint.params.inflation_max = "0.000000000000000000" |
+                .app_state.gov.params.voting_period = $voting_period |
                 .app_state.gov.voting_params.voting_period = $voting_period
             ' <"$GENESIS_FILE_PATH"
         )"


### PR DESCRIPTION
For spawning a new chain with sdk >=0.47, the voting_period lies under gov.params in genesis. Updated the script accordingly. 

**How got to know?**
Started a fresh testnet with 66 docker image with a changed VOTING_PERIOD env. It didn't work (and that's how further dig came to this problem).

**NOTE:**
_I'll further look if any other hierarchy  of params is changed and affected_