### PR TITLE
Recreate tmp folder instead of bash expansion for rm

### DIFF
--- a/bases/node/node.yaml
+++ b/bases/node/node.yaml
@@ -136,6 +136,12 @@ spec:
                   name: instagoric-release
                   key: PRUNING
                   optional: true
+            - name: PRUNING_KEEP_RECENT
+              valueFrom:
+                configMapKeyRef:
+                  name: instagoric-release
+                  key: PRUNING_KEEP_RECENT
+                  optional: true
             - name: AUTO_APPROVE_PROPOSAL
               valueFrom:
                 configMapKeyRef:

--- a/bases/shared/scripts/main.sh
+++ b/bases/shared/scripts/main.sh
@@ -20,8 +20,9 @@ source "$CURRENT_DIRECTORY_PATH/util.sh"
 set -x
 
 mkdir --parents "$AGORIC_HOME" "$TMPDIR"
-# shellcheck disable=SC2086,SC2115
-rm --force --recursive -- $TMPDIR/..?* $TMPDIR/.[!.]* $TMPDIR/*
+
+rm --force --recursive "$TMPDIR"
+mkdir --parents "$TMPDIR"
 
 resolved_config="${BOOTSTRAP_CONFIG//"@agoric"/"$SDK_ROOT_PATH/packages"}"
 
@@ -187,9 +188,11 @@ case "$ROLE" in
         curl "$MAINNET_ADDRBOOK_URL" --fail --location --output "/state/addrbook.json" --silent
         cp --force "/state/addrbook.json" "$AGORIC_HOME/config/addrbook.json"
 
+        update_pruning_config
         sed "$AGORIC_HOME/config/app.toml" \
             --expression 's|^snapshot-interval = .*|snapshot-interval = 0|' \
             --in-place
+
         touch "/state/$FOLLOWER_STATEFUL_SET_NAME-initialized"
     fi
 

--- a/bases/shared/scripts/util.sh
+++ b/bases/shared/scripts/util.sh
@@ -587,17 +587,7 @@ start_helper() {
 }
 
 update_config_files() {
-    if test -n "$PRUNING"; then
-        sed --in-place "s/^pruning =.*/pruning = \"$PRUNING\"/" "$AGORIC_HOME/config/app.toml"
-    else
-        sed "$AGORIC_HOME/config/app.toml" \
-            --expression 's|^pruning-interval =.*|pruning-interval = 1000|' \
-            --expression 's|^pruning-keep-every =.*|pruning-keep-every = 1000|' \
-            --expression 's|^pruning-keep-recent =.*|pruning-keep-recent = 10000|' \
-            --expression '/^\[state-sync]/,/^\[/{s|^snapshot-interval =.*|snapshot-interval = 1000|}' \
-            --expression '/^\[state-sync]/,/^\[/{s|^snapshot-keep-recent =.*|snapshot-keep-recent = 10|}' \
-            --in-place
-    fi
+    update_pruning_config
 
     sed "$AGORIC_HOME/config/app.toml" \
         --expression '/^\[api]/,/^\[/{s|^address =.*|address = "tcp://0.0.0.0:1317"|}' \
@@ -622,6 +612,23 @@ update_config_files() {
         --expression 's|^prometheus = false|prometheus = true|' \
         --expression "/^\[rpc]/,/^\[/{s|^laddr =.*|laddr = 'tcp://0.0.0.0:$RPC_PORT'|}" \
         --in-place
+}
+
+update_pruning_config() {
+    if test -n "$PRUNING"; then
+        sed --in-place "s|^pruning =.*|pruning = \"$PRUNING\"|" "$AGORIC_HOME/config/app.toml"
+
+        if test -n "$PRUNING_KEEP_RECENT"; then
+            sed --in-place "s|^pruning-keep-recent =.*|pruning-keep-recent = $PRUNING_KEEP_RECENT|" "$AGORIC_HOME/config/app.toml"
+        fi
+    else
+        sed "$AGORIC_HOME/config/app.toml" \
+            --expression 's|^pruning-interval =.*|pruning-interval = 1000|' \
+            --expression 's|^pruning-keep-recent =.*|pruning-keep-recent = 10000|' \
+            --expression '/^\[state-sync]/,/^\[/{s|^snapshot-interval =.*|snapshot-interval = 1000|}' \
+            --expression '/^\[state-sync]/,/^\[/{s|^snapshot-keep-recent =.*|snapshot-keep-recent = 10|}' \
+            --in-place
+    fi
 }
 
 update_swingset_config_file() {


### PR DESCRIPTION
## Description

We explicitly set `TMPDIR="/state/tmp"` in the start script which is why this folder is used for yarn cache

Although we explicitly clear this folder on every boot using `rm --force --recursive -- $TMPDIR/..?* $TMPDIR/.[!.]* $TMPDIR/*`, this is susceptible to failure for a long file list (as bash is responsible for expanding the `*` to all the files inside the folder)

We simply need to recreate the `/state/tmp` folder on boot instead of this method

Also added support for setting pruning limits